### PR TITLE
Implements --allow-dirty on sync method

### DIFF
--- a/gitvendor/cli.py
+++ b/gitvendor/cli.py
@@ -32,6 +32,8 @@ def setup_parser():
     sync.add_argument('-t', '--tag', help='Tag to vendor')
     sync.add_argument('-d', '--directory',
                       default='.', help='Output Directory')
+    sync.add_argument('--allow-dirty', action='store_true',
+                      help='Allow operations on a dirty repository')
 
     return p
 

--- a/gitvendor/helpers.py
+++ b/gitvendor/helpers.py
@@ -7,12 +7,12 @@ import yaml
 log = logging.getLogger('git-vendor.helpers')
 
 
-def is_repository_clean(directory):
+def is_repository_clean(directory, force):
     """ repository_sanity: predicate method for checking the status of a dirty'
     repository"""
 
     repo = Repo(directory)
-    if repo.is_dirty():
+    if repo.is_dirty() and not force:
         log.warn('Repository is dirty, doing nothing')
         return False
     return True

--- a/gitvendor/sync.py
+++ b/gitvendor/sync.py
@@ -70,7 +70,8 @@ def main(args, debug):
     if not args.repo:
         args.repo = '.'
     path = is_path_sane(args.repo)
-    dirty = is_repository_clean(args.repo)
+    force = args.allow_dirty
+    dirty = is_repository_clean(args.repo, force)
     initialized = is_repository_initialized(args.repo)
 
     if not path and not dirty:


### PR DESCRIPTION
This allows you to make post-commits on a repository that will only
effect the working copy, (such as to the vendor-sync file) but will not
effect the tag based workflow.

Its common to add new things to a project that are meta, and to not
update your vendor-rc file (while it is contained in version control).
Whatever the reason, the tool should not encourage a forced update
workflow for exporting.
